### PR TITLE
Add dockerfile for cfdatabasetool

### DIFF
--- a/cfdatabasetool/.gitignore
+++ b/cfdatabasetool/.gitignore
@@ -1,0 +1,3 @@
+target/
+.idea/
+*.iml

--- a/cfdatabasetool/Dockerfile
+++ b/cfdatabasetool/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jre
+
+COPY target/cfdatabasetool*.jar /opt/cfdatabasetool.jar
+
+EXPOSE 9000
+
+ENTRYPOINT [ "java", "-jar", "/opt/cfdatabasetool.jar" ]

--- a/cfdatabasetool/README.md
+++ b/cfdatabasetool/README.md
@@ -1,0 +1,11 @@
+# cfdatabasetool
+
+## Building
+1. Run `mvn install` to build jar
+1. Run `docker build . -t sdcplatform/cfdatabasetool` to build docker images
+
+## Publish docker image
+Run `docker push sdcplatform/cfdatabasetool:latest`
+
+## Running
+Run `docker run -p 9000:9000 sdcplatform/cfdatabasetool:latest`


### PR DESCRIPTION
cfdatabasetool is needed to run the integration tests. We should be able
to run the integration tests by brining up rm services and required
external services via docker.

In the long run we would ideally be able to run the integration tests
by driving APIs instead of manipulating data via cfdatabasetool. Until
then it should be easy to bring into the stack from running tests
locally.

For make the docker image available to pull down by anyone we can
manually push up the image. It is unlikely to change often so this
shouldn't be a problem. If it does change often we should create a build
which publishes the docker image.