### PR TITLE
Look for jars not containing docker

### DIFF
--- a/scripts/pipeline/update_ci_versions.sh
+++ b/scripts/pipeline/update_ci_versions.sh
@@ -25,4 +25,4 @@ cd ..
 
 # Move jar to correct location
 mkdir target
-find . -type f -name "*.jar" -not -name "*docker-info*" -exec mv {} target/$ARTIFACT_ID.jar \;
+find . -type f -name "*.jar" -not -name "*docker-info*" -exec mv -v {} target/$ARTIFACT_ID.jar \;

--- a/scripts/pipeline/update_ci_versions.sh
+++ b/scripts/pipeline/update_ci_versions.sh
@@ -25,4 +25,4 @@ cd ..
 
 # Move jar to correct location
 mkdir target
-find . -type f -name "*.jar" -not -name "*docker-info*" -exec mv -v {} target/$ARTIFACT_ID.jar \;
+find . -type f -name "*$ARTIFACT_ID*.jar" -not -name "*docker-info*" -exec mv -v {} target/$ARTIFACT_ID.jar \;

--- a/scripts/pipeline/update_ci_versions.sh
+++ b/scripts/pipeline/update_ci_versions.sh
@@ -25,4 +25,4 @@ cd ..
 
 # Move jar to correct location
 mkdir target
-find . -iregex ".*[^docker].jar" -exec mv {} target/$ARTIFACT_ID.jar \;
+find . -type f -name "*.jar" -not -name "*docker-info*" -exec mv {} target/$ARTIFACT_ID.jar \;

--- a/scripts/pipeline/update_ci_versions.sh
+++ b/scripts/pipeline/update_ci_versions.sh
@@ -25,4 +25,4 @@ cd ..
 
 # Move jar to correct location
 mkdir target
-mv *.jar target/$ARTIFACT_ID.jar
+find . -iregex ".*[^docker].jar" -exec mv {} target/$ARTIFACT_ID.jar \;


### PR DESCRIPTION
Now we use the spotify docker maven plugin to build docker images an
extra jar is output from the plugin. The scripts expect only one jar to
exist. We've changed the script to look for jars that do not include the
text docker in the filename.