### PR TITLE
Us004 load events

### DIFF
--- a/collex-loader/load_events.py
+++ b/collex-loader/load_events.py
@@ -76,7 +76,8 @@ def get_collection_exercise_uuid(row, api_config):
 
     try:
         if data['error']:
-            raise ValueError(data['error']['message'])
+            # There are 2 different formats of the data depending on what kind of error it is, so just dump it out as json
+            raise ValueError(json.dumps(data))
     except KeyError:
         return data['id']
 

--- a/collex-loader/load_events.py
+++ b/collex-loader/load_events.py
@@ -76,7 +76,7 @@ def get_collection_exercise_uuid(row, api_config):
 
     try:
         if data['error']:
-            raise ValueError(data['message'])
+            raise ValueError(data['error']['message'])
     except KeyError:
         return data['id']
 


### PR DESCRIPTION
Turns out there are 2 formats for error objects in responses from collection exercise service.  This change just dumps out the object instead of cherry picking the message so should work with both (ALL!) formats