### PR TITLE
Fixed bad request

### DIFF
--- a/social-test-setup/scripts/create_action_rules.py
+++ b/social-test-setup/scripts/create_action_rules.py
@@ -13,7 +13,7 @@ def create_action_rules(action_plan_id: str):
         'actionTypeName': 'SOCIALPRENOT',
         'name': 'OHSSOCIALPRENOT+0',
         'description': 'OHS Social Pre-notification (+0 days)',
-        'daysOffset': 0,
+        'triggerDateTime': '2018-08-06T10:27:16.997Z',
         'priority': 3
     }
 
@@ -22,7 +22,7 @@ def create_action_rules(action_plan_id: str):
         'actionTypeName': 'SOCIALNOT',
         'name': 'OHSSOCIALNOT +0',
         'description': 'OHS Social Notification (+0 days)',
-        'daysOffset': 0,
+        'triggerDateTime': '2018-08-06T10:27:16.997Z',
         'priority': 3
     }
 


### PR DESCRIPTION
# Motivation and Context
Without this change we can't load social test data. This fix will change the request so that it supplies a date and time rather than an offset.

# What has changed
Changed daysOffset to triggerDateTime in accordance to API changes

# How to test?
Run make setup-and-execute in rm-tools/social-test-setup