### PR TITLE
update social test setup eq form type

### DIFF
--- a/social-test-setup/scripts/upload_collection_instrument.py
+++ b/social-test-setup/scripts/upload_collection_instrument.py
@@ -9,7 +9,7 @@ def upload_ci(survey_id: str, collection_exercise_id: str):
     querystring = {'survey_id': survey_id,
                    'classifiers': f'{{"collection_exercise":"{collection_exercise_id}",'
                                   f'"eq_id":"lms",'
-                                  f'"form_type":"1"}}'}
+                                  f'"form_type":"2"}}'}
 
     upload_response = requests.post(f'{Config.COLLECTION_INSTRUMENT_SERVICE_URL}'
                                     f'/collection-instrument-api/1.0.2/upload',


### PR DESCRIPTION
# Motivation and Context
EQ are using a new version 2 schema for LMS, this PR updates the social test setup collection instrument form type to use this newer schema, primarily for the respondent-home-ui integration tests.

# What has changed
* Updated the collection instrument form type to '2' in social test setup

# How to test?
Run the response home integration tests on this branch: https://github.com/ONSdigital/respondent-home-ui/pull/53
against this branch of rm tools by modifying the data_setup.sh script in RH to point to this branch like this:
```shell
git clone --depth 1 ${rm_tools_repo_url} --single-branch -b update-social-eq-form-type tmp_rm_tools;
```

# Links
https://trello.com/c/QwnRHhx2/291-bug291-respondent-home-ui-tries-to-use-addressline1-as-runame
https://github.com/ONSdigital/respondent-home-ui/pull/53
