### PR TITLE
Extend collection exercise end date for integration tests

### DIFF
--- a/social-test-setup/data/test-1-events.csv
+++ b/social-test-setup/data/test-1-events.csv
@@ -1,2 +1,2 @@
 survey_code,survey_period,mps,go_live,return_by,exercise_end,ref_period_start,ref_period_end
-999,1,230718,240718,040818,310720,240718,040818
+999,1,230718,240718,040818,310720,240718,040820


### PR DESCRIPTION
# Motivation and Context
RH currently uses the `ref_period_end` to check whether a collection exercise is "closed". With the introduction of the feature in https://github.com/ONSdigital/respondent-home-ui/pull/69 the only collection exercise is considered closed and the tests are unable to progress.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Extended the `ref_period_end` to 2020.

